### PR TITLE
gui: make max FPS slider dynamic based on monitor refresh rate

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -38,6 +38,8 @@ import org.joml.Vector4f;
 import org.jspecify.annotations.Nullable;
 import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.GLCapabilities;
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWVidMode;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -141,24 +143,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                 .addPage(this.buildPerformancePage(builder));
     }
 
-private OptionPageBuilder buildGeneralPage(ConfigBuilder builder) {
-        int monitorRefreshRate = 60;
-        try {
-            long windowHandle = Minecraft.getInstance().getWindow().handle();
-            long monitorHandle = org.lwjgl.glfw.GLFW.glfwGetWindowMonitor(windowHandle);
-            if (monitorHandle == 0L) {
-                monitorHandle = org.lwjgl.glfw.GLFW.glfwGetPrimaryMonitor();
-            }
-            org.lwjgl.glfw.GLFWVidMode vidMode = org.lwjgl.glfw.GLFW.glfwGetVideoMode(monitorHandle);
-            if (vidMode != null) {
-                monitorRefreshRate = vidMode.refreshRate();
-            }
-        } catch (Exception e) {
-            // fallback if window context is uninitialized during early config building
-        }
-        int dynamicMaxFps = Math.max(260, ((monitorRefreshRate + 9) / 10) * 10 + 10);
-        final int finalMaxFps = dynamicMaxFps;
-        
+    private OptionPageBuilder buildGeneralPage(ConfigBuilder builder) {
         var generalPage = builder.createOptionPage().setName(Component.translatable("sodium.options.pages.general"));
         generalPage.addOptionGroup(builder.createOptionGroup()
                 .addOption(
@@ -320,8 +305,10 @@ private OptionPageBuilder buildGeneralPage(ConfigBuilder builder) {
                                 .setStorageHandler(this.vanillaStorage)
                                 .setName(Component.translatable("options.framerateLimit"))
                                 .setTooltip(Component.translatable("sodium.options.fps_limit.tooltip"))
-                                .setValueFormatter(value -> value >= finalMaxFps ? Component.translatable("options.framerateLimit.max") : Component.literal(value + " FPS"))
-                                .setRange(10, finalMaxFps, 10)
+                                .setValueFormatter(ControlValueFormatterImpls.fpsLimit())
+                                .setValidatorProvider(
+                                        (state) -> new Range(10, this.getMaxFramerateLimit(), 10),
+                                        ConfigState.UPDATE_ON_REBUILD, ConfigState.UPDATE_ON_APPLY)
                                 .setDefaultValue(60)
                                 .setBinding(this.vanillaOpts.framerateLimit()::set, this.vanillaOpts.framerateLimit()::get)
                 )
@@ -345,8 +332,50 @@ private OptionPageBuilder buildGeneralPage(ConfigBuilder builder) {
                                 .setBinding(this.vanillaOpts.showAutosaveIndicator()::set, this.vanillaOpts.showAutosaveIndicator()::get)
                 )
         );
+        generalPage.addOptionGroup(builder.createOptionGroup().addOption(builder.createEnumOption(Identifier.fromNamespaceAndPath("sodium", "general.graphics_api"),
+                        PreferredGraphicsApi.class)
+                .setStorageHandler(this.vanillaStorage)
+                .setName(Component.translatable("options.graphicsApi"))
+                .setTooltip(i -> {
+                    if (i == PreferredGraphicsApi.VULKAN) {
+                        return Component.translatable("options.graphicsApi.tooltip.vulkan");
+                    } else {
+                        return Component.translatable("options.graphicsApi.tooltip");
+                    }
+                })
+                .setElementNameProvider(EnumOptionBuilder.nameProviderFrom(
+                        Component.translatable("options.graphicsApi.default"),
+                        Component.translatable("options.graphicsApi.opengl"),
+                        Component.literal("Prefer Vulkan")))
+                .setDefaultValue(PreferredGraphicsApi.DEFAULT)
+                .setFlags(OptionFlag.REQUIRES_GAME_RESTART)
+                .setBinding((value) -> this.vanillaOpts.preferredGraphicsBackend().set(value), () -> this.vanillaOpts.preferredGraphicsBackend().get())));
 
         return generalPage;
+    }
+
+    /**
+     * this computes an appropriate maximum for the framerate limit slider based on the current
+     * monitor's refresh rate, so users on high-refresh-rate displays aren't capped at 260
+     * + falls back to the vanilla default max if the window/monitor context isn't available yet
+     * (e.g. during early config building).
+     */
+    private int getMaxFramerateLimit() {
+        int monitorRefreshRate = 60;
+        try {
+            long windowHandle = Minecraft.getInstance().getWindow().handle();
+            long monitorHandle = GLFW.glfwGetWindowMonitor(windowHandle);
+            if (monitorHandle == 0L) {
+                monitorHandle = GLFW.glfwGetPrimaryMonitor();
+            }
+            GLFWVidMode vidMode = GLFW.glfwGetVideoMode(monitorHandle);
+            if (vidMode != null) {
+                monitorRefreshRate = vidMode.refreshRate();
+            }
+        } catch (Exception e) {
+            // fallback if window/monitor context is unavailable
+        }
+        return Math.max(260, ((monitorRefreshRate + 9) / 10) * 10 + 10);
     }
 
     private OptionPageBuilder buildQualityPage(ConfigBuilder builder) {

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -141,7 +141,24 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                 .addPage(this.buildPerformancePage(builder));
     }
 
-    private OptionPageBuilder buildGeneralPage(ConfigBuilder builder) {
+private OptionPageBuilder buildGeneralPage(ConfigBuilder builder) {
+        int monitorRefreshRate = 60;
+        try {
+            long windowHandle = Minecraft.getInstance().getWindow().handle();
+            long monitorHandle = org.lwjgl.glfw.GLFW.glfwGetWindowMonitor(windowHandle);
+            if (monitorHandle == 0L) {
+                monitorHandle = org.lwjgl.glfw.GLFW.glfwGetPrimaryMonitor();
+            }
+            org.lwjgl.glfw.GLFWVidMode vidMode = org.lwjgl.glfw.GLFW.glfwGetVideoMode(monitorHandle);
+            if (vidMode != null) {
+                monitorRefreshRate = vidMode.refreshRate();
+            }
+        } catch (Exception e) {
+            // fallback if window context is uninitialized during early config building
+        }
+        int dynamicMaxFps = Math.max(260, ((monitorRefreshRate + 9) / 10) * 10 + 10);
+        final int finalMaxFps = dynamicMaxFps;
+        
         var generalPage = builder.createOptionPage().setName(Component.translatable("sodium.options.pages.general"));
         generalPage.addOptionGroup(builder.createOptionGroup()
                 .addOption(
@@ -303,8 +320,8 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                 .setStorageHandler(this.vanillaStorage)
                                 .setName(Component.translatable("options.framerateLimit"))
                                 .setTooltip(Component.translatable("sodium.options.fps_limit.tooltip"))
-                                .setValueFormatter(ControlValueFormatterImpls.fpsLimit())
-                                .setRange(10, 260, 10)
+                                .setValueFormatter(value -> value >= finalMaxFps ? Component.translatable("options.framerateLimit.max") : Component.literal(value + " FPS"))
+                                .setRange(10, finalMaxFps, 10)
                                 .setDefaultValue(60)
                                 .setBinding(this.vanillaOpts.framerateLimit()::set, this.vanillaOpts.framerateLimit()::get)
                 )
@@ -328,24 +345,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                 .setBinding(this.vanillaOpts.showAutosaveIndicator()::set, this.vanillaOpts.showAutosaveIndicator()::get)
                 )
         );
-        generalPage.addOptionGroup(builder.createOptionGroup().addOption(builder.createEnumOption(Identifier.fromNamespaceAndPath("sodium", "general.graphics_api"),
-                PreferredGraphicsApi.class)
-                .setStorageHandler(this.vanillaStorage)
-                .setName(Component.translatable("options.graphicsApi"))
-                .setTooltip(i -> {
-                    if (i == PreferredGraphicsApi.VULKAN) {
-                        return Component.translatable("options.graphicsApi.tooltip.vulkan");
-                    } else {
-                        return Component.translatable("options.graphicsApi.tooltip");
-                    }
-                })
-                .setElementNameProvider(EnumOptionBuilder.nameProviderFrom(
-                        Component.translatable("options.graphicsApi.default"),
-                        Component.translatable("options.graphicsApi.opengl"),
-                        Component.literal("Prefer Vulkan")))
-                .setDefaultValue(PreferredGraphicsApi.DEFAULT)
-                .setFlags(OptionFlag.REQUIRES_GAME_RESTART)
-                .setBinding((value) -> this.vanillaOpts.preferredGraphicsBackend().set(value), () -> this.vanillaOpts.preferredGraphicsBackend().get())));
+
         return generalPage;
     }
 

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -333,7 +333,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                 )
         );
         generalPage.addOptionGroup(builder.createOptionGroup().addOption(builder.createEnumOption(Identifier.fromNamespaceAndPath("sodium", "general.graphics_api"),
-                        PreferredGraphicsApi.class)
+                PreferredGraphicsApi.class)
                 .setStorageHandler(this.vanillaStorage)
                 .setName(Component.translatable("options.graphicsApi"))
                 .setTooltip(i -> {
@@ -363,7 +363,8 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
     private int getMaxFramerateLimit() {
         int monitorRefreshRate = 60;
         try {
-            long windowHandle = Minecraft.getInstance().getWindow().handle();
+        if (this.window != null){
+            long windowHandle = this.window.handle();
             long monitorHandle = GLFW.glfwGetWindowMonitor(windowHandle);
             if (monitorHandle == 0L) {
                 monitorHandle = GLFW.glfwGetPrimaryMonitor();
@@ -372,6 +373,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
             if (vidMode != null) {
                 monitorRefreshRate = vidMode.refreshRate();
             }
+        }
         } catch (Exception e) {
             // fallback if window/monitor context is unavailable
         }


### PR DESCRIPTION
Fixes #3781: Automatically calculate the slider's upper bound based on the current monitor's refresh rate, removing the static hardcoded cap and providing better support for high-refresh-rate displays