### PR TITLE
Re-enable the "Fullscreen Resolution" control on Linux

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/SodiumConfigBuilder.java
@@ -15,7 +15,6 @@ import net.caffeinemc.mods.sodium.api.config.option.OptionImpact;
 import net.caffeinemc.mods.sodium.api.config.option.Range;
 import net.caffeinemc.mods.sodium.api.config.structure.*;
 import net.caffeinemc.mods.sodium.client.SodiumClientMod;
-import net.caffeinemc.mods.sodium.client.compatibility.environment.OsUtils;
 import net.caffeinemc.mods.sodium.client.compatibility.workarounds.Workarounds;
 import net.caffeinemc.mods.sodium.client.config.structure.Config;
 import net.caffeinemc.mods.sodium.client.gui.options.FullscreenMode;
@@ -282,10 +281,8 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
                                             if (monitor == null || monitor.modeCount() <= 0) {
                                                 return false;
                                             }
-                                            var os = OsUtils.getOs();
                                             var fullscreenMode = state.readEnumOption(Identifier.parse("sodium:general.fullscreen_mode"), FullscreenMode.class);
-                                            return (os == OsUtils.OperatingSystem.WIN || os == OsUtils.OperatingSystem.MAC) &&
-                                                    fullscreenMode == FullscreenMode.EXCLUSIVE;
+                                            return fullscreenMode == FullscreenMode.EXCLUSIVE;
                                         },
                                         Identifier.parse("sodium:general.fullscreen_mode"))
                                 .setFlags(OptionFlag.REQUIRES_VIDEOMODE_RELOAD)

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ControlValueFormatterImpls.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gui/options/control/ControlValueFormatterImpls.java
@@ -2,7 +2,6 @@ package net.caffeinemc.mods.sodium.client.gui.options.control;
 
 import com.mojang.blaze3d.platform.Monitor;
 import net.caffeinemc.mods.sodium.api.config.option.ControlValueFormatter;
-import net.caffeinemc.mods.sodium.client.compatibility.environment.OsUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 
@@ -20,8 +19,7 @@ public class ControlValueFormatterImpls {
         return (v) -> {
             Monitor monitor = Minecraft.getInstance().getWindow().findBestMonitor();
 
-            var os = OsUtils.getOs();
-            if (monitor == null || !(os == OsUtils.OperatingSystem.WIN || os == OsUtils.OperatingSystem.MAC)) {
+            if (monitor == null) {
                 return Component.empty();
             } else if (0 == v) {
                 return Component.translatable("options.fullscreen.current");

--- a/common/src/main/resources/assets/sodium/lang/en_us.json
+++ b/common/src/main/resources/assets/sodium/lang/en_us.json
@@ -17,7 +17,7 @@
   "sodium.options.fullscreen_mode.exclusive" : "Exclusive",
   "sodium.options.fullscreen_mode.borderless" : "Borderless",
   "sodium.options.fullscreen_mode.tooltip" : "Exclusive fullscreen can improve latency, but may prevent some input methods from working and slow down switching out of the game. Borderless fullscreen can cause significant performance degradation.",
-  "sodium.options.fullscreen_resolution.tooltip": "The monitor resolution and refresh rate to be used when in fullscreen mode. Changing this option may interfere with other applications and cause a delay when switching between applications.\n\nThis is only supported on the Windows or macOS operating systems.",
+  "sodium.options.fullscreen_resolution.tooltip": "The monitor resolution and refresh rate to be used when in fullscreen mode. Changing this option may interfere with other applications and cause a delay when switching between applications.",
   "sodium.options.v_sync.tooltip": "If enabled, the game's frame rate will be synchronized to the monitor's refresh rate, making for a generally smoother experience at the expense of overall input latency. This setting might reduce performance if your system is too slow.",
   "sodium.options.fps_limit.tooltip": "Limits the maximum number of frames per second. This can help reduce battery usage and system load when multi-tasking. If VSync is enabled, this option will be ignored unless it is lower than your display's refresh rate.",
   "sodium.options.attack_indicator.tooltip": "Controls where the Attack Indicator is displayed on screen.",


### PR DESCRIPTION
Hi! As of today, there's no longer a need to artificially disable the resolution control on Linux - it now works properly on the major Wayland desktops. I've tested it on my laptop with KDE 6.6.5 and GNOME 50 using both Vulkan and OpenGL, as well as both my Intel iGPU and Nvidia dGPU *(can it even be called that?)*. Here are some examples:

| ![sodium-xwayland-opengl-nvidia](https://github.com/user-attachments/assets/5966a12f-63ff-440e-ad62-8cb207feaa94) | ![sodium-xwayland-vulkan-nvidia](https://github.com/user-attachments/assets/ed40eafd-8f7c-4095-97a0-7215af9cf772) | ![sodium-xwayland-opengl-intel](https://github.com/user-attachments/assets/3fab1b2f-fbd5-42f1-96c2-19854c8ed84b) |
|-|-|-|

I also tested changing Minecraft's fullscreen resolution on another machine running an older version of KDE (6.4.3), and there it still doesn't work, which suggests that something was fixed/improved relatively recently. However, the important thing here is that the issue is no longer present on the latest-ish versions of the said desktop environments.

And since the problem is no longer reproducible on KDE and GNOME, which make up like 99% of the modern Linux desktop, and the consensus in #2831 seems to be that it doesn't make sense to withhold this feature from everyone just because it may still be a bit junky on a handful of systems, I think it's time to retire this check.
