### PR TITLE
Optimise pitcher plants

### DIFF
--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_0.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_0.json
@@ -1,0 +1,24 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "block/pitcher_crop_top",
+        "pitcher_top": "block/pitcher_crop_top",
+        "pitcher_side": "block/pitcher_crop_side",
+        "pitcher_bottom": "block/pitcher_crop_bottom"
+    },
+    "elements": [
+        {
+            "name": "pitcher_crop_bottom_stage_0",
+            "from": [5, -1, 5],
+            "to": [11, 3, 11],
+            "faces": {
+                "north": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
+                "east": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
+                "south": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
+                "west": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
+                "up": {"uv": [5, 5, 11, 11], "texture": "#pitcher_top"},
+                "down": {"uv": [5, 5, 11, 11], "texture": "#pitcher_bottom", "cullface": "down"}
+            }
+        }
+    ]
+}

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_0.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_0.json
@@ -9,15 +9,15 @@
     "elements": [
         {
             "name": "pitcher_crop_bottom_stage_0",
-            "from": [5, -1, 5],
-            "to": [11, 3, 11],
+            "from": [ 5, -1, 5 ],
+            "to": [ 11, 3, 11 ],
             "faces": {
-                "north": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
-                "east": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
-                "south": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
-                "west": {"uv": [3, 10, 9, 14], "texture": "#pitcher_side"},
-                "up": {"uv": [5, 5, 11, 11], "texture": "#pitcher_top"},
-                "down": {"uv": [5, 5, 11, 11], "texture": "#pitcher_bottom", "cullface": "down"}
+                "north": { "uv": [ 3, 10, 9, 14 ], "texture": "#pitcher_side" },
+                "east": { "uv": [ 3, 10, 9, 14 ], "texture": "#pitcher_side" },
+                "south": { "uv": [ 3, 10, 9, 14 ], "texture": "#pitcher_side" },
+                "west": { "uv": [ 3, 10, 9, 14 ], "texture": "#pitcher_side" },
+                "up": { "uv": [ 5, 5, 11, 11 ], "texture": "#pitcher_top" },
+                "down": { "uv": [ 5, 5, 11, 11 ], "texture": "#pitcher_bottom", "cullface": "down" }
             }
         }
     ]

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_1.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_1.json
@@ -1,0 +1,47 @@
+{
+	"ambientocclusion": false,
+	"textures": {
+        "particle": "block/pitcher_crop_top",
+		"stage_1": "block/pitcher_crop_bottom_stage_1",
+		"pitcher_top": "block/pitcher_crop_top",
+		"pitcher_side": "block/pitcher_crop_side",
+        "pitcher_bottom": "block/pitcher_crop_bottom"
+    },
+	"elements": [
+		{
+			"name": "pitcher_crop_bottom_stage_1",
+			"from": [0, 5, 8],
+			"to": [16, 21, 8],
+			"shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 5, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_1"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_1",
+			"from": [0, 5, 8],
+			"to": [16, 21, 8],
+			"shade": false,
+			"rotation": {"angle": -45, "axis": "y", "origin": [8, 5, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_1"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_1",
+			"from": [3, -1, 3],
+			"to": [13, 5, 13],
+			"faces": {
+				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
+				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
+			}
+		}
+	]
+}

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_1.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_1.json
@@ -1,47 +1,47 @@
 {
-	"ambientocclusion": false,
-	"textures": {
+    "ambientocclusion": false,
+    "textures": {
         "particle": "block/pitcher_crop_top",
-		"stage_1": "block/pitcher_crop_bottom_stage_1",
-		"pitcher_top": "block/pitcher_crop_top",
-		"pitcher_side": "block/pitcher_crop_side",
+        "stage_1": "block/pitcher_crop_bottom_stage_1",
+        "pitcher_top": "block/pitcher_crop_top",
+        "pitcher_side": "block/pitcher_crop_side",
         "pitcher_bottom": "block/pitcher_crop_bottom"
     },
-	"elements": [
-		{
-			"name": "pitcher_crop_bottom_stage_1",
-			"from": [0, 5, 8],
-			"to": [16, 21, 8],
-			"shade": false,
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 5, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_1"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_1"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_1",
-			"from": [0, 5, 8],
-			"to": [16, 21, 8],
-			"shade": false,
-			"rotation": {"angle": -45, "axis": "y", "origin": [8, 5, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_1"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_1"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_1",
-			"from": [3, -1, 3],
-			"to": [13, 5, 13],
-			"faces": {
-				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
-				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
-			}
-		}
-	]
+    "elements": [
+        {
+            "name": "pitcher_crop_bottom_stage_1",
+            "from": [ 0, 5, 8 ],
+            "to": [ 16, 21, 8 ],
+            "shade": false,
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 5, 8 ] },
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_1" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_1" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_1",
+            "from": [ 0, 5, 8 ],
+            "to": [ 16, 21, 8 ],
+            "shade": false,
+            "rotation": { "angle": -45, "axis": "y", "origin": [ 8, 5, 8 ] },
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_1" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_1" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_1",
+            "from": [ 3, -1, 3 ],
+            "to": [ 13, 5, 13 ],
+            "faces": {
+                "north": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "east": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "south": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "west": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "up": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_top" },
+                "down": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_bottom", "cullface": "down" }
+            }
+        }
+    ]
 }

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_2.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_2.json
@@ -1,0 +1,47 @@
+{
+	"ambientocclusion": false,
+	"textures": {
+        "particle": "block/pitcher_crop_top",
+		"stage_2": "block/pitcher_crop_bottom_stage_2",
+		"pitcher_top": "block/pitcher_crop_top",
+		"pitcher_side": "block/pitcher_crop_side",
+        "pitcher_bottom": "block/pitcher_crop_bottom"
+    },
+	"elements": [
+		{
+			"name": "pitcher_crop_bottom_stage_2",
+			"from": [0, 5, 8],
+			"to": [16, 21, 8],
+			"shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 6, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_2"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_2"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_2",
+			"from": [8, 5, 0],
+			"to": [8, 21, 16],
+			"shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 6, 8]},
+			"faces": {
+				"east": {"uv": [0, 0, 16, 16], "texture": "#stage_2"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#stage_2"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_1",
+			"from": [3, -1, 3],
+			"to": [13, 5, 13],
+			"faces": {
+				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
+				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
+			}
+		}
+	]
+}

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_2.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_2.json
@@ -1,47 +1,47 @@
 {
-	"ambientocclusion": false,
-	"textures": {
+    "ambientocclusion": false,
+    "textures": {
         "particle": "block/pitcher_crop_top",
-		"stage_2": "block/pitcher_crop_bottom_stage_2",
-		"pitcher_top": "block/pitcher_crop_top",
-		"pitcher_side": "block/pitcher_crop_side",
+        "stage_2": "block/pitcher_crop_bottom_stage_2",
+        "pitcher_top": "block/pitcher_crop_top",
+        "pitcher_side": "block/pitcher_crop_side",
         "pitcher_bottom": "block/pitcher_crop_bottom"
     },
-	"elements": [
-		{
-			"name": "pitcher_crop_bottom_stage_2",
-			"from": [0, 5, 8],
-			"to": [16, 21, 8],
-			"shade": false,
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 6, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_2"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_2"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_2",
-			"from": [8, 5, 0],
-			"to": [8, 21, 16],
-			"shade": false,
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 6, 8]},
-			"faces": {
-				"east": {"uv": [0, 0, 16, 16], "texture": "#stage_2"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#stage_2"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_1",
-			"from": [3, -1, 3],
-			"to": [13, 5, 13],
-			"faces": {
-				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
-				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
-			}
-		}
-	]
+    "elements": [
+        {
+            "name": "pitcher_crop_bottom_stage_2",
+            "from": [ 0, 5, 8 ],
+            "to": [ 16, 21, 8 ],
+            "shade": false,
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 6, 8 ] },
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_2" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_2" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_2",
+            "from": [ 8, 5, 0 ],
+            "to": [ 8, 21, 16 ],
+            "shade": false,
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 6, 8 ] },
+            "faces": {
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_2" },
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_2" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_1",
+            "from": [ 3, -1, 3 ],
+            "to": [ 13, 5, 13 ],
+            "faces": {
+                "north": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "east": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "south": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "west": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "up": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_top" },
+                "down": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_bottom", "cullface": "down" }
+            }
+        }
+    ]
 }

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_3.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_3.json
@@ -1,0 +1,47 @@
+{
+	"ambientocclusion": false,
+	"textures": {
+        "particle": "block/pitcher_crop_top",
+		"stage_3_bottom": "block/pitcher_crop_bottom_stage_3",
+		"pitcher_top": "block/pitcher_crop_top",
+		"pitcher_side": "block/pitcher_crop_side",
+        "pitcher_bottom": "block/pitcher_crop_bottom"
+	},
+	"elements": [
+		{
+			"name": "pitcher_crop_bottom_stage_3",
+			"from": [0, 0, 8],
+			"to": [16, 16, 8],
+            "shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_3",
+			"from": [0, 0, 8],
+			"to": [16, 16, 8],
+            "shade": false,
+			"rotation": {"angle": -45, "axis": "y", "origin": [8, 0, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_1",
+			"from": [3, -1, 3],
+			"to": [13, 5, 13],
+			"faces": {
+				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
+				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
+			}
+		}
+	]
+}

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_3.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_3.json
@@ -1,47 +1,47 @@
 {
-	"ambientocclusion": false,
-	"textures": {
+    "ambientocclusion": false,
+    "textures": {
         "particle": "block/pitcher_crop_top",
-		"stage_3_bottom": "block/pitcher_crop_bottom_stage_3",
-		"pitcher_top": "block/pitcher_crop_top",
-		"pitcher_side": "block/pitcher_crop_side",
+        "stage_3_bottom": "block/pitcher_crop_bottom_stage_3",
+        "pitcher_top": "block/pitcher_crop_top",
+        "pitcher_side": "block/pitcher_crop_side",
         "pitcher_bottom": "block/pitcher_crop_bottom"
-	},
-	"elements": [
-		{
-			"name": "pitcher_crop_bottom_stage_3",
-			"from": [0, 0, 8],
-			"to": [16, 16, 8],
+    },
+    "elements": [
+        {
+            "name": "pitcher_crop_bottom_stage_3",
+            "from": [ 0, 0, 8 ],
+            "to": [ 16, 16, 8 ],
             "shade": false,
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_3",
-			"from": [0, 0, 8],
-			"to": [16, 16, 8],
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 0, 8 ] },
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_3_bottom" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_3_bottom" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_3",
+            "from": [ 0, 0, 8 ],
+            "to": [ 16, 16, 8 ],
             "shade": false,
-			"rotation": {"angle": -45, "axis": "y", "origin": [8, 0, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_3_bottom"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_1",
-			"from": [3, -1, 3],
-			"to": [13, 5, 13],
-			"faces": {
-				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
-				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
-			}
-		}
-	]
+            "rotation": { "angle": -45, "axis": "y", "origin": [ 8, 0, 8 ] },
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_3_bottom" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_3_bottom" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_1",
+            "from": [ 3, -1, 3 ],
+            "to": [ 13, 5, 13 ],
+            "faces": {
+                "north": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "east": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "south": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "west": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "up": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_top" },
+                "down": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_bottom", "cullface": "down" }
+            }
+        }
+    ]
 }

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_4.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_4.json
@@ -1,0 +1,47 @@
+{
+	"ambientocclusion": false,
+	"textures": {
+        "particle": "block/pitcher_crop_top",
+		"stage_4_bottom": "block/pitcher_crop_bottom_stage_4",
+		"pitcher_top": "block/pitcher_crop_top",
+		"pitcher_side": "block/pitcher_crop_side",
+		"pitcher_bottom": "block/pitcher_crop_bottom"
+	},
+	"elements": [
+		{
+			"name": "pitcher_crop_bottom_stage_4",
+			"from": [8, 0, 0],
+			"to": [8, 16, 16],
+            "shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
+			"faces": {
+				"east": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_4",
+			"from": [0, 0, 8],
+			"to": [16, 16, 8],
+            "shade": false,
+			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"}
+			}
+		},
+		{
+			"name": "pitcher_crop_bottom_stage_1",
+			"from": [3, -1, 3],
+			"to": [13, 5, 13],
+			"faces": {
+				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
+				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
+				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
+			}
+		}
+	]
+}

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_4.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_crop_bottom_stage_4.json
@@ -1,47 +1,47 @@
 {
-	"ambientocclusion": false,
-	"textures": {
+    "ambientocclusion": false,
+    "textures": {
         "particle": "block/pitcher_crop_top",
-		"stage_4_bottom": "block/pitcher_crop_bottom_stage_4",
-		"pitcher_top": "block/pitcher_crop_top",
-		"pitcher_side": "block/pitcher_crop_side",
-		"pitcher_bottom": "block/pitcher_crop_bottom"
-	},
-	"elements": [
-		{
-			"name": "pitcher_crop_bottom_stage_4",
-			"from": [8, 0, 0],
-			"to": [8, 16, 16],
+        "stage_4_bottom": "block/pitcher_crop_bottom_stage_4",
+        "pitcher_top": "block/pitcher_crop_top",
+        "pitcher_side": "block/pitcher_crop_side",
+        "pitcher_bottom": "block/pitcher_crop_bottom"
+    },
+    "elements": [
+        {
+            "name": "pitcher_crop_bottom_stage_4",
+            "from": [ 8, 0, 0 ],
+            "to": [ 8, 16, 16 ],
             "shade": false,
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
-			"faces": {
-				"east": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_4",
-			"from": [0, 0, 8],
-			"to": [16, 16, 8],
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 0, 8 ] },
+            "faces": {
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_4_bottom" },
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_4_bottom" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_4",
+            "from": [ 0, 0, 8 ],
+            "to": [ 16, 16, 8 ],
             "shade": false,
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#stage_4_bottom"}
-			}
-		},
-		{
-			"name": "pitcher_crop_bottom_stage_1",
-			"from": [3, -1, 3],
-			"to": [13, 5, 13],
-			"faces": {
-				"north": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"east": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"south": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"west": {"uv": [3, 10, 13, 16], "texture": "#pitcher_side"},
-				"up": {"uv": [3, 3, 13, 13], "texture": "#pitcher_top"},
-				"down": {"uv": [3, 3, 13, 13], "texture": "#pitcher_bottom", "cullface": "down"}
-			}
-		}
-	]
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 0, 8 ] },
+            "faces": {
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_4_bottom" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#stage_4_bottom" }
+            }
+        },
+        {
+            "name": "pitcher_crop_bottom_stage_1",
+            "from": [ 3, -1, 3 ],
+            "to": [ 13, 5, 13 ],
+            "faces": {
+                "north": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "east": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "south": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "west": { "uv": [ 3, 10, 13, 16 ], "texture": "#pitcher_side" },
+                "up": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_top" },
+                "down": { "uv": [ 3, 3, 13, 13 ], "texture": "#pitcher_bottom", "cullface": "down" }
+            }
+        }
+    ]
 }

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_bottom.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_bottom.json
@@ -1,0 +1,31 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "block/pitcher_crop_bottom_stage_4",
+        "bottom": "block/pitcher_crop_bottom_stage_4"
+    },
+    "elements": [
+        {
+            "name": "pitcher_plant_bottom",
+            "from": [8, -5, 0],
+            "to": [8, 11, 16],
+            "shade": false,
+            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "faces": {
+                "east": {"uv": [0, 0, 16, 16], "texture": "#bottom"},
+                "west": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
+            }
+        },
+        {
+            "name": "pitcher_plant_bottom",
+            "from": [0, -5, 8],
+            "to": [16, 11, 8],
+            "shade": false,
+            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "faces": {
+                "north": {"uv": [0, 0, 16, 16], "texture": "#bottom"},
+                "south": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
+            }
+        }
+    ]
+}

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_bottom.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_bottom.json
@@ -7,24 +7,24 @@
     "elements": [
         {
             "name": "pitcher_plant_bottom",
-            "from": [8, -5, 0],
-            "to": [8, 11, 16],
+            "from": [ 8, -5, 0 ],
+            "to": [ 8, 11, 16 ],
             "shade": false,
-            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 3, 8 ] },
             "faces": {
-                "east": {"uv": [0, 0, 16, 16], "texture": "#bottom"},
-                "west": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom" },
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom" }
             }
         },
         {
             "name": "pitcher_plant_bottom",
-            "from": [0, -5, 8],
-            "to": [16, 11, 8],
+            "from": [ 0, -5, 8 ],
+            "to": [ 16, 11, 8 ],
             "shade": false,
-            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 3, 8 ] },
             "faces": {
-                "north": {"uv": [0, 0, 16, 16], "texture": "#bottom"},
-                "south": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom" }
             }
         }
     ]

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_top.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_top.json
@@ -7,24 +7,24 @@
     "elements": [
         {
             "name": "pitcher_plant_top",
-            "from": [8, -5, 0],
-            "to": [8, 11, 16],
+            "from": [ 8, -5, 0 ],
+            "to": [ 8, 11, 16 ],
             "shade": false,
-            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 3, 8 ] },
             "faces": {
-                "east": {"uv": [0, 0, 16, 16], "texture": "#top"},
-                "west": {"uv": [0, 0, 16, 16], "texture": "#top"}
+                "east": { "uv": [ 0, 0, 16, 16 ], "texture": "#top" },
+                "west": { "uv": [ 0, 0, 16, 16 ], "texture": "#top" }
             }
         },
         {
             "name": "pitcher_plant_top",
-            "from": [0, -5, 8],
-            "to": [16, 11, 8],
+            "from": [ 0, -5, 8 ],
+            "to": [ 16, 11, 8 ],
             "shade": false,
-            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "rotation": { "angle": 45, "axis": "y", "origin": [ 8, 3, 8 ] },
             "faces": {
-                "north": {"uv": [0, 0, 16, 16], "texture": "#top"},
-                "south": {"uv": [0, 0, 16, 16], "texture": "#top"}
+                "north": { "uv": [ 0, 0, 16, 16 ], "texture": "#top" },
+                "south": { "uv": [ 0, 0, 16, 16 ], "texture": "#top" }
             }
         }
     ]

--- a/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_top.json
+++ b/common/src/main/resources/assets/minecraft/models/block/pitcher_plant_top.json
@@ -1,0 +1,31 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "block/pitcher_crop_top_stage_4",
+        "top": "block/pitcher_crop_top_stage_4"
+    },
+    "elements": [
+        {
+            "name": "pitcher_plant_top",
+            "from": [8, -5, 0],
+            "to": [8, 11, 16],
+            "shade": false,
+            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "faces": {
+                "east": {"uv": [0, 0, 16, 16], "texture": "#top"},
+                "west": {"uv": [0, 0, 16, 16], "texture": "#top"}
+            }
+        },
+        {
+            "name": "pitcher_plant_top",
+            "from": [0, -5, 8],
+            "to": [16, 11, 8],
+            "shade": false,
+            "rotation": {"angle": 45, "axis": "y", "origin": [8, 3, 8]},
+            "faces": {
+                "north": {"uv": [0, 0, 16, 16], "texture": "#top"},
+                "south": {"uv": [0, 0, 16, 16], "texture": "#top"}
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds some minor optimizations to pitcher plant models, which affect all Sodium versions they are present in (1.20.1, 1.21.1, 1.21.11, 26.1.x, 26.2.x). It makes the following changes:

Eliminates excess faces in the pitcher_plant models. The vanilla model defines six faces per plane when only two are needed.
Adds cullfaces to the "bulbs" of pitcher_crop models. Unfortunately these will not cull against farmland blocks (which the crop can only be placed on in vanilla survival), but this might be useful to builders or mapmakers who can utilise the blocks more freely. It doesn't hurt to have them.
I did not change the mapping of the affected models or the texture references, only the changes listed above. They should appear identical and this seemed to be the case in some quick testing I did.

---

This is a new PR since the old one couldn't merge. I hope it's correct now, I'm still learning how git works.