### PR TITLE
Fix OpenGL performance regression on some systems since 26.2

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/GlFenceSyncMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/GlFenceSyncMixin.java
@@ -7,13 +7,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(targets = "com.mojang.blaze3d.opengl.GlCommandEncoder")
 public class GlFenceSyncMixin {
 
-    @Redirect(
-            method = "submit",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lorg/lwjgl/opengl/GL33C;glFenceSync(II)J"
-            )
-    )
+    @Redirect(method = "submit", at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL33C;glFenceSync(II)J"))
     private long sodium$disableGlFenceSync(int condition, int flags) {
         return 0L;
     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/GlFenceSyncMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/GlFenceSyncMixin.java
@@ -1,0 +1,21 @@
+package net.caffeinemc.mods.sodium.mixin.core;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(targets = "com.mojang.blaze3d.opengl.GlCommandEncoder")
+public class GlFenceSyncMixin {
+
+    @Redirect(
+            method = "submit",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lorg/lwjgl/opengl/GL33C;glFenceSync(II)J"
+            )
+    )
+    private long sodium$disableGlFenceSync(int condition, int flags) {
+        return 0L;
+    }
+
+}

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -14,6 +14,7 @@
     "minVersion": "0.5.2"
   },
   "client": [
+    "core.GlFenceSyncMixin",
     "core.GlRenderPassAccessor",
     "core.GpuDeviceAccessor",
     "core.MinecraftMixin",


### PR DESCRIPTION
26.2 seems to have introduced a major OpenGL performance regression, which halves the framerate on some systems in almost all situations (at least on Apple Silicon devices).

Could reproduce on an M1 Max system in a newly created flat world (~230 FPS without the fix, ~580 FPS with the fix).

Problem is present since 26.2 pre-release 1 (since this version, a GL fence sync seems to be created unconditionally for each frame).

This PR contains a small mixin to work around this, which fixed the problem in my case (and hopefully also for others).

Since I don't have much experience with OpenGL or rendering, I'm not sure if this could have unintended side effects, but I haven't encountered any issues in my testing.

Would be great to have this tested on different systems and hardware configurations to see whether the issue is specific to my setup or affects other systems as well.