### PR TITLE
Fully backport 26.3 changes and fix a mixin

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/GlDeviceMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/GlDeviceMixin.java
@@ -1,0 +1,41 @@
+package net.caffeinemc.mods.sodium.mixin.core;
+
+import com.mojang.blaze3d.opengl.GlDevice;
+import com.mojang.blaze3d.opengl.GlStateManager;
+import com.mojang.blaze3d.shaders.GpuDebugOptions;
+import com.mojang.blaze3d.shaders.ShaderSource;
+import org.lwjgl.opengl.GL33;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Locale;
+
+@Mixin(GlDevice.class)
+public class GlDeviceMixin {
+    @Shadow
+    protected static boolean USE_GL_ARB_buffer_storage;
+
+    // Disable ARB_buffer_storage on NVIDIA and Intel Gen7 devices, to avoid some strange stall behavior.
+    @Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/opengl/BufferStorage;create(Lorg/lwjgl/opengl/GLCapabilities;Ljava/util/Set;)Lcom/mojang/blaze3d/opengl/BufferStorage;"))
+    private void sodium$disableBufferStorage(long windowHandle, ShaderSource defaultShaderSource, GpuDebugOptions debugOptions, CallbackInfo ci) {
+        String vendor = GlStateManager._getString(GL33.GL_VENDOR);
+        String renderer = GlStateManager._getString(GL33.GL_RENDERER);
+
+        boolean isNvidia = renderer.toLowerCase(Locale.ROOT).contains("nvidia");
+        boolean couldBeIntelGen7;
+        if (!vendor.contains("intel")) {
+            couldBeIntelGen7 = false;
+        } else if (renderer.contains("2500")) {
+            couldBeIntelGen7 = true;
+        } else if (renderer.contains("4000")) {
+            couldBeIntelGen7 = true;
+        } else {
+            couldBeIntelGen7 = renderer.contains("hd graphics (byt)") || renderer.endsWith("hd graphics");
+        }
+
+        USE_GL_ARB_buffer_storage = !(isNvidia || couldBeIntelGen7);
+    }
+}

--- a/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/StagedVertexBufferMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/mixin/core/StagedVertexBufferMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 // This backports a fix from 26.3 Snapshot 6 that improves performance on OpenGL.
-@Mixin(targets = "net.minecraft.client.renderer.StagedVertexBuffer.GpuBufferPool")
+@Mixin(targets = "net.minecraft.client.renderer.StagedVertexBuffer$GpuBufferPool")
 public abstract class StagedVertexBufferMixin {
     @Shadow
     protected abstract void tryRecycleBuffers();

--- a/common/src/main/resources/sodium-common.mixins.json
+++ b/common/src/main/resources/sodium-common.mixins.json
@@ -14,6 +14,7 @@
     "minVersion": "0.5.2"
   },
   "client": [
+    "core.GlDeviceMixin",
     "core.GlRenderPassAccessor",
     "core.GpuDeviceAccessor",
     "core.MinecraftMixin",


### PR DESCRIPTION
Backport vanilla change in 26.3 snapshot9 which disables ARB_buffer_storage on NVIDIA and Intel Gen7 devices to fully fix MC-307596.

Fixed wrong mixin targets in commit e8a8ee3. Considering it can partly solve the problem when running with Iris Shaders, I guess we may better keep the fix here.